### PR TITLE
chore: generate data (or skip it) before release

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,11 +1,6 @@
 name: Generate
 on:
-  workflow_dispatch
-  # push:
-  #   branches:
-  #     - master
-  #   paths:
-  #     - src/generate.js
+  [workflow_dispatch, repository_dispatch]
 
 jobs:
   generate:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,6 +1,7 @@
 name: Generate
 on:
-  [workflow_dispatch, repository_dispatch]
+  repository_dispatch:
+    types: [generate]
 
 jobs:
   generate:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,6 +1,11 @@
 name: Generate
 on:
   workflow_dispatch
+  # push:
+  #   branches:
+  #     - master
+  #   paths:
+  #     - src/generate.js
 
 jobs:
   generate:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,5 +1,6 @@
 name: Generate
 on:
+  workflow_dispatch
   repository_dispatch:
     types: [generate]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Changes
         id: file_changes
-        uses: trilom/file-changes-action@v1.2
+        uses: trilom/file-changes-action@v1.2.4
       - name: Generate
         uses: convictional/trigger-workflow-and-wait@v1.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release
 on:
-  push:
-    branches:
-      - master
+  push
+    # branches:
+    #   - master
 
 jobs:
   data:
@@ -46,8 +46,8 @@ jobs:
         uses: montudor/action-zip@v0.1.0
         with:
           args: unzip -qq ./data/canadian-city-timezones.zip -d ./src
-      - name: Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
+      # - name: Release
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      #   run: npx semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,50 @@ on:
       - master
 
 jobs:
+  data:
+    name: Data
+    runs-on: ubuntu-latest
+    steps:
+      - name: Changes
+        id: file_changes
+        uses: trilom/file-changes-action@v1.2
+      - uses: actions/checkout@v2
+        if: ${{ contains(steps.file_changes.outputs.files_modified, 'src/generate.js') }}
+      - uses: actions/setup-node@v1
+        if: ${{ contains(steps.file_changes.outputs.files_modified, 'src/generate.js') }}
+        with:
+          node-version: '12'
+      - name: Install
+        if: ${{ contains(steps.file_changes.outputs.files_modified, 'src/generate.js') }}
+        run: npm ci
+      - name: Generate
+        if: ${{ contains(steps.file_changes.outputs.files_modified, 'src/generate.js') }}
+        env:
+          MAP_BOX_API_KEY: ${{ secrets.MAP_BOX_API_KEY }}
+        run: |
+          node ./src/generate.js data.csv
+          mkdir -p data
+      - name: Zip
+        if: ${{ contains(steps.file_changes.outputs.files_modified, 'src/generate.js') }}
+        uses: montudor/action-zip@v0.1.0
+        with:
+          args: zip -qq data/canadian-city-timezones.zip data.csv
+      - name: Upload
+        if: ${{ contains(steps.file_changes.outputs.files_modified, 'src/generate.js') }}
+        uses: autovance/s3-sync-action@master
+        with:
+          args: --acl public-read --follow-symlinks --delete
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          # AWS_REGION: 'ca-central-1'
+          SOURCE_DIR: data
+          DEST_DIR: s3://${{ secrets.AWS_S3_BUCKET }}/data
+
   release:
     name: Release
     runs-on: ubuntu-latest
+    needs: data
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,38 +12,16 @@ jobs:
       - name: Changes
         id: file_changes
         uses: trilom/file-changes-action@v1.2
-      - uses: actions/checkout@v2
-        if: ${{ contains(steps.file_changes.outputs.files_modified, 'src/generate.js') }}
-      - uses: actions/setup-node@v1
-        if: ${{ contains(steps.file_changes.outputs.files_modified, 'src/generate.js') }}
-        with:
-          node-version: '12'
-      - name: Install
-        if: ${{ contains(steps.file_changes.outputs.files_modified, 'src/generate.js') }}
-        run: npm ci
       - name: Generate
-        if: ${{ contains(steps.file_changes.outputs.files_modified, 'src/generate.js') }}
-        env:
-          MAP_BOX_API_KEY: ${{ secrets.MAP_BOX_API_KEY }}
-        run: |
-          node ./src/generate.js data.csv
-          mkdir -p data
-      - name: Zip
-        if: ${{ contains(steps.file_changes.outputs.files_modified, 'src/generate.js') }}
-        uses: montudor/action-zip@v0.1.0
+        uses: convictional/trigger-workflow-and-wait@v1.0.1
         with:
-          args: zip -qq data/canadian-city-timezones.zip data.csv
-      - name: Upload
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          wait_interval: 30
+          event_type: Generate
+          ref: ${{ github.ref }}
         if: ${{ contains(steps.file_changes.outputs.files_modified, 'src/generate.js') }}
-        uses: autovance/s3-sync-action@master
-        with:
-          args: --acl public-read --follow-symlinks --delete
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          # AWS_REGION: 'ca-central-1'
-          SOURCE_DIR: data
-          DEST_DIR: s3://${{ secrets.AWS_S3_BUCKET }}/data
 
   release:
     name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release
 on:
-  push
-    # branches:
-    #   - master
+  push:
+    branches:
+      - master
 
 jobs:
   data:
@@ -24,33 +24,33 @@ jobs:
           wait_interval: 30
           event_type: generate
           ref: ${{ github.ref }}
-        # if: ${{ contains(steps.file_changes.outputs.files, 'src/generate.js') }}
+        if: ${{ contains(steps.file_changes.outputs.files, 'src/generate.js') }}
 
-  # release:
-  #   name: Release
-  #   runs-on: ubuntu-latest
-  #   needs: data
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-node@v1
-  #     - name: Setup
-  #       run: mkdir -p data
-  #     - name: Download
-  #       uses: autovance/s3-sync-action@master
-  #       with:
-  #         args: --acl public-read --follow-symlinks --delete
-  #       env:
-  #         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         # AWS_REGION: 'ca-central-1'
-  #         SOURCE_DIR: s3://${{ secrets.AWS_S3_BUCKET }}/data
-  #         DEST_DIR: data
-  #     - name: Unzip
-  #       uses: montudor/action-zip@v0.1.0
-  #       with:
-  #         args: unzip -qq ./data/canadian-city-timezones.zip -d ./src
-  #     - name: Release
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  #       run: npx semantic-release
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: data
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - name: Setup
+        run: mkdir -p data
+      - name: Download
+        uses: autovance/s3-sync-action@master
+        with:
+          args: --acl public-read --follow-symlinks --delete
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          # AWS_REGION: 'ca-central-1'
+          SOURCE_DIR: s3://${{ secrets.AWS_S3_BUCKET }}/data
+          DEST_DIR: data
+      - name: Unzip
+        uses: montudor/action-zip@v0.1.0
+        with:
+          args: unzip -qq ./data/canadian-city-timezones.zip -d ./src
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,12 @@ jobs:
       - name: Changes
         id: file_changes
         uses: trilom/file-changes-action@v1.2.4
+      - name: List
+        run: |
+          echo '${{ steps.file_changes.outputs.files}}'
+          echo '${{ steps.file_changes.outputs.files_modified}}'
+          echo '${{ steps.file_changes.outputs.files_added}}'
+          echo '${{ steps.file_changes.outputs.files_removed}}'
       - name: Generate
         uses: convictional/trigger-workflow-and-wait@v1.0.1
         with:
@@ -23,29 +29,29 @@ jobs:
           ref: ${{ github.ref }}
         if: ${{ contains(steps.file_changes.outputs.files_modified, 'src/generate.js') }}
 
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    needs: data
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-      - name: Setup
-        run: mkdir -p data
-      - name: Download
-        uses: autovance/s3-sync-action@master
-        with:
-          args: --acl public-read --follow-symlinks --delete
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          # AWS_REGION: 'ca-central-1'
-          SOURCE_DIR: s3://${{ secrets.AWS_S3_BUCKET }}/data
-          DEST_DIR: data
-      - name: Unzip
-        uses: montudor/action-zip@v0.1.0
-        with:
-          args: unzip -qq ./data/canadian-city-timezones.zip -d ./src
+  # release:
+  #   name: Release
+  #   runs-on: ubuntu-latest
+  #   needs: data
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-node@v1
+  #     - name: Setup
+  #       run: mkdir -p data
+  #     - name: Download
+  #       uses: autovance/s3-sync-action@master
+  #       with:
+  #         args: --acl public-read --follow-symlinks --delete
+  #       env:
+  #         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         # AWS_REGION: 'ca-central-1'
+  #         SOURCE_DIR: s3://${{ secrets.AWS_S3_BUCKET }}/data
+  #         DEST_DIR: data
+  #     - name: Unzip
+  #       uses: montudor/action-zip@v0.1.0
+  #       with:
+  #         args: unzip -qq ./data/canadian-city-timezones.zip -d ./src
       # - name: Release
       #   env:
       #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,6 @@ jobs:
       - name: List
         run: |
           echo '${{ steps.file_changes.outputs.files}}'
-          echo '${{ steps.file_changes.outputs.files_modified}}'
-          echo '${{ steps.file_changes.outputs.files_added}}'
-          echo '${{ steps.file_changes.outputs.files_removed}}'
       - name: Generate
         uses: convictional/trigger-workflow-and-wait@v1.0.1
         with:
@@ -25,9 +22,9 @@ jobs:
           repo: ${{ github.event.repository.name }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           wait_interval: 30
-          event_type: Generate
+          event_type: generate
           ref: ${{ github.ref }}
-        if: ${{ contains(steps.file_changes.outputs.files_modified, 'src/generate.js') }}
+        # if: ${{ contains(steps.file_changes.outputs.files, 'src/generate.js') }}
 
   # release:
   #   name: Release
@@ -52,8 +49,8 @@ jobs:
   #       uses: montudor/action-zip@v0.1.0
   #       with:
   #         args: unzip -qq ./data/canadian-city-timezones.zip -d ./src
-      # - name: Release
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      #   run: npx semantic-release
+  #     - name: Release
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  #       run: npx semantic-release

--- a/src/generate.js
+++ b/src/generate.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+// REMOVE ME
+
 const { createWriteStream, mkdir, createReadStream } = require('fs');
 const { dirname } = require('path');
 const { pipeline, Readable, Transform } = require('stream');

--- a/src/generate.js
+++ b/src/generate.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
-// REMOVE ME
-
 const { createWriteStream, mkdir, createReadStream } = require('fs');
 const { dirname } = require('path');
 const { pipeline, Readable, Transform } = require('stream');


### PR DESCRIPTION
On push to master, see if `src/generate.js` was changed. If it was, trigger the `Generate` workflow and wait for it to finish, otherwise skip this step. After the `data` step is skipped or completed, run the `release` step.

Fixes: https://github.com/autovance/canadian-city-timezones/issues/8